### PR TITLE
Add package & executable parameter to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This syntax adds the `composition/composition::Talker` as a ComposableNode
     sl.node(package='composition', plugin='Talker', name='talker')
 ```
 
-Use the `executable` parameter if you want to use executors other than `component_container`:
+Use the `executable` and `package` parameters if you want to use executors other than `rclcpp_components`'s `component_container`:
 
 ```
   with sl.container(name='my_container', output='screen', executable='component_container_isolated'):

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ This syntax adds the `composition/composition::Talker` as a ComposableNode
     sl.node(package='composition', plugin='Talker', name='talker')
 ```
 
+Use the `executable` parameter if you want to use executors other than `component_container`:
+
+```
+  with sl.container(name='my_container', output='screen', executable='component_container_isolated'):
+```
+
 ## Simulation and `use_sim_time`
 
 Instanciating `sl = SimpleLauncher(use_sim_time = True)` is equivalent to:

--- a/src/simple_launch/__init__.py
+++ b/src/simple_launch/__init__.py
@@ -410,7 +410,7 @@ class SimpleLauncher:
             
             
     @contextmanager
-    def container(self, name, namespace = '', existing = False, **container_args):
+    def container(self, name, namespace = '', existing = False, package='rclcpp_components', executable='component_container', **container_args):
         '''
         Opens a Composition group to add nodes
         If existing is True, then loads nodes in the (supposely) existing container
@@ -437,8 +437,8 @@ class SimpleLauncher:
                 ComposableNodeContainer(
                 name=name,
                 namespace=namespace,
-                package='rclcpp_components',
-                executable='component_container',
+                package=package,
+                executable=executable,
                 composable_node_descriptions=new_entities,
                 **container_args))
                 


### PR DESCRIPTION
This allows the user to use a component container implementation other than `component_container`, such as `component_container_isolated` and `component_container_mt`.