### PR TITLE
Fix string-valued launch argument substitution

### DIFF
--- a/simple_launch/__init__.py
+++ b/simple_launch/__init__.py
@@ -213,6 +213,8 @@ class SimpleLauncher:
             if performed.lower() in ('true', 'false'):
                 return literal_eval(performed.title())
             return performed
+        except SyntaxError:
+            return performed
 
     def py_eval(self, *elems):
         '''


### PR DESCRIPTION
Consider a launch file that declares an argument meant to be used as a string,
in this example an IP address.

```
from simple_launch import SimpleLauncher

sl = SimpleLauncher()

sl.declare_arg('robot_ip', '10.0.30.112')


def launch():
    print(sl.arg('robot_ip'))
    return sl.launch_description()


generate_launch_description = sl.launch_description(opaque_function=launch)
```

Performing the substitution as above inside the opaque function context results
in an `SyntaxError` being thrown since the given literal value `10.0.30.112` --
as seen by `ast.literal_eval` -- cannot be interpreted as valid Python.

My suggested fix is simply catching this exception and returning any such
"invalid" inputs as strings.

It might be worth noting that one can bodge a fix on the user side as follows:

```
sl.declare_arg('robot_ip', '"10.0.30.112"')

ros2 launch ... robot_ip:=\"10.0.30.112\"
```
Note the additional quotes to force interpretation as a Python string.

P.S. Thank you for making this wonderful library. With it, I no longer feel existential
dread when faced with launching off a few ROS 2 nodes...