### PR TITLE
add group to parent rather than root group, fixes nested groups

### DIFF
--- a/simple_launch/group.py
+++ b/simple_launch/group.py
@@ -53,9 +53,9 @@ class Group:
                 ns_tree = list(map(PushRosNamespace, self.__ns))
                 group = GroupAction(ns_tree + self.__actions, condition=self.__condition)
             if self.__when is not None:
-                self.__root.add_action(self.__when.register(group))
+                self.__parent.add_action(self.__when.register(group))
             else:
-                self.__root.add_action(group)
+                self.__parent.add_action(group)
 
         return self.__parent
 


### PR DESCRIPTION
Hello, I'd like to propose a fix for a behavior I'd consider a bug: when nesting groups, for example in [event_tutorial_launch.py#L34](https://github.com/oKermorgant/simple_launch/blob/devel/example/event_tutorial_launch.py#L34), nested group behaves as if it was a top-level group, i.e. in linked example time counts from launch start rather than from "spawn_turtle" execution completion.

launchfile on which I tested the fix:
https://github.com/aurzenligl/study/blob/master/ros2/demo/launch/events/example_event_handlers.simple.py#L28

logs from launchfile execution with and without simple_launch fix:
https://github.com/aurzenligl/study/blob/master/ros2/demo/launch/events/README.md
